### PR TITLE
fix(CU-869448adv): stack spec mutates on creation

### DIFF
--- a/api/v1beta1/stack_types.go
+++ b/api/v1beta1/stack_types.go
@@ -32,7 +32,7 @@ type StackSpec struct {
 
 type StackInput struct {
 	AdditionalProjectGlobs *[]string     `json:"additionalProjectGlobs,omitempty"`
-	Administrative         bool          `json:"administrative,omitempty"`
+	Administrative         *bool         `json:"administrative,omitempty"`
 	AfterApply             *[]string     `json:"afterApply,omitempty"`
 	AfterDestroy           *[]string     `json:"afterDestroy,omitempty"`
 	AfterInit              *[]string     `json:"afterInit,omitempty"`

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -292,6 +292,11 @@ func (in *StackInput) DeepCopyInto(out *StackInput) {
 			copy(*out, *in)
 		}
 	}
+	if in.Administrative != nil {
+		in, out := &in.Administrative, &out.Administrative
+		*out = new(bool)
+		**out = **in
+	}
 	if in.AfterApply != nil {
 		in, out := &in.AfterApply, &out.AfterApply
 		*out = new([]string)

--- a/internal/spacelift/repository/structs/stack_input.go
+++ b/internal/spacelift/repository/structs/stack_input.go
@@ -93,8 +93,14 @@ type TerraformInput struct {
 }
 
 func FromStackSpec(stackSpec v1beta1.StackSpec) StackInput {
+
+	administrative := getGraphQLBoolean(stackSpec.Settings.Administrative)
+	if administrative == nil {
+		administrative = graphql.NewBoolean(false)
+	}
+
 	ret := StackInput{
-		Administrative:      graphql.Boolean(stackSpec.Settings.Administrative),
+		Administrative:      *administrative,
 		Autodeploy:          getGraphQLBoolean(stackSpec.Settings.Autodeploy),
 		Autoretry:           getGraphQLBoolean(stackSpec.Settings.Autoretry),
 		Branch:              graphql.String(stackSpec.Settings.Branch),

--- a/tests/integration/stack_suite.go
+++ b/tests/integration/stack_suite.go
@@ -27,7 +27,6 @@ var DefaultValidStack = v1beta1.Stack{
 		CommitSHA: "ed56c7b20e3dd075013cf0d7ab3ce083fdb7900f",
 		Settings: v1beta1.StackInput{
 			ManagesStateFile: false,
-			Administrative:   false,
 			Branch:           "fake-branch",
 			Repository:       "fake-repository",
 		},


### PR DESCRIPTION
At stack creation, we set the stack link in a special annotation and we trigger an update.
The problem is that we have the `omitempty` field on the required administrative settings. If administrative is set to false, the field is dropped from the CRD during update.
This was causing the stack to appear as not in sync in argo.