### PR TITLE
fix: vcs namespace can contains slashed on azure devops

### DIFF
--- a/internal/spacelift/repository/structs/stack_input.go
+++ b/internal/spacelift/repository/structs/stack_input.go
@@ -108,9 +108,10 @@ func FromStackSpec(stackSpec v1beta1.StackSpec) StackInput {
 
 	var namespace *string
 	var repo = stackSpec.Settings.Repository
-	repoSplit := strings.SplitN(repo, "/", 2)
-	if len(repoSplit) == 2 {
-		namespace, repo = &repoSplit[0], repoSplit[1]
+	if pos := strings.LastIndexByte(repo, '/'); pos != -1 {
+		ns := repo[:pos]
+		repo = repo[pos+1:]
+		namespace = &ns
 	}
 
 	ret := StackInput{


### PR DESCRIPTION
See https://github.com/spacelift-io/spacelift-operator/pull/19/files#diff-1c2b6bb7f5afa714b162456628aa4b8d46ab306c286a67cd1c2f2b08fde2e344R111