### PR TITLE
chore(CU-8694k86bg): cleanup stack output creation

### DIFF
--- a/api/v1beta1/events.go
+++ b/api/v1beta1/events.go
@@ -1,0 +1,3 @@
+package v1beta1
+
+const EventReasonStackOutputCreated = "StackOutputCreated"

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -109,7 +109,7 @@ func main() {
 
 	runRepo := repository.NewRunRepository(mgr.GetClient(), mgr.GetScheme())
 	stackRepo := repository.NewStackRepository(mgr.GetClient())
-	stackOutputRepo := repository.NewStackOutputRepository(mgr.GetClient(), mgr.GetScheme())
+	stackOutputRepo := repository.NewStackOutputRepository(mgr.GetClient(), mgr.GetScheme(), mgr.GetEventRecorderFor("stack-output-repository"))
 	spaceliftRunRepo := spaceliftRepository.NewRunRepository(mgr.GetClient())
 	spaceliftStackRepo := spaceliftRepository.NewStackRepository(mgr.GetClient())
 	runWatcher := watcher.NewRunWatcher(runRepo, spaceliftRunRepo)

--- a/internal/controller/run_controller_test.go
+++ b/internal/controller/run_controller_test.go
@@ -28,7 +28,7 @@ type RunControllerSuite struct {
 
 func (s *RunControllerSuite) SetupSuite() {
 	s.SetupManager = func(mgr manager.Manager) {
-		stackOutputRepo := repository.NewStackOutputRepository(mgr.GetClient(), mgr.GetScheme())
+		stackOutputRepo := repository.NewStackOutputRepository(mgr.GetClient(), mgr.GetScheme(), mgr.GetEventRecorderFor("stack-output-repository"))
 		s.RunRepo = repository.NewRunRepository(mgr.GetClient(), mgr.GetScheme())
 		s.FakeSpaceliftRunRepo = new(mocks.RunRepository)
 		s.FakeSpaceliftStackRepo = new(mocks.StackRepository)

--- a/internal/k8s/repository/stack_output_test.go
+++ b/internal/k8s/repository/stack_output_test.go
@@ -1,0 +1,108 @@
+package repository_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/suite"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+
+	"github.com/spacelift-io/spacelift-operator/api/v1beta1"
+	"github.com/spacelift-io/spacelift-operator/internal/k8s/repository"
+	"github.com/spacelift-io/spacelift-operator/internal/spacelift/models"
+	"github.com/spacelift-io/spacelift-operator/tests/integration"
+)
+
+type StackOutputRepositorySuite struct {
+	integration.IntegrationTestSuite
+	integration.WithEventHelper
+	integration.WithStackSuiteHelper
+	repo *repository.StackOutputRepository
+}
+
+func (s *StackOutputRepositorySuite) SetupSuite() {
+	s.SetupManager = func(manager manager.Manager) {
+		s.repo = repository.NewStackOutputRepository(
+			manager.GetClient(),
+			manager.GetScheme(),
+			manager.GetEventRecorderFor("stack-output-repository"),
+		)
+	}
+	s.WithEventHelper = integration.WithEventHelper{
+		IntegrationTestSuite: &s.IntegrationTestSuite,
+	}
+	s.WithStackSuiteHelper = integration.WithStackSuiteHelper{
+		IntegrationTestSuite: &s.IntegrationTestSuite,
+	}
+	s.IntegrationTestSuite.SetupSuite()
+}
+
+func (s *StackOutputRepositorySuite) TestUpdateOrCreateStackOutputSecret_OK_WithInvalidOutputs() {
+	validStack := v1beta1.Stack{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "foobar",
+		},
+		Spec: v1beta1.StackSpec{
+			Name: "foobar",
+		},
+	}
+
+	stack := validStack
+	err := s.Client().Create(s.Context(), &stack)
+	s.Require().NoError(err)
+	defer s.DeleteStack(&stack)
+
+	outputs := []models.StackOutput{
+		{
+			Id:    "foo",
+			Value: "bar",
+		},
+		{
+			Id:    "foo!",
+			Value: "invalid special char",
+		},
+		{
+			Id:    "",
+			Value: "invalid empty",
+		},
+		{
+			Id:    "bar",
+			Value: "foo",
+		},
+	}
+
+	secret, err := s.repo.UpdateOrCreateStackOutputSecret(s.Context(), &stack, outputs)
+	s.Require().NoError(err)
+	s.Equal("stack-output-foobar", secret.Name)
+
+	// Ensure owner reference is set
+	s.Require().Len(secret.OwnerReferences, 1)
+	s.Equal("Stack", secret.OwnerReferences[0].Kind)
+	s.Equal("foobar", secret.OwnerReferences[0].Name)
+
+	// Assert that data is set even if some fields are ignored
+	s.Contains(secret.Data, "bar")
+	s.EqualValues(secret.Data["bar"], "foo")
+	s.Contains(secret.Data, "foo")
+	s.EqualValues(secret.Data["foo"], "bar")
+
+	var events []v1.Event
+	s.Eventually(func() bool {
+		events, _ = s.FindEvents(types.NamespacedName{Namespace: secret.Namespace, Name: secret.Name}, v1beta1.EventReasonStackOutputCreated)
+		return len(events) == 1
+	}, integration.DefaultTimeout, integration.DefaultInterval)
+
+	s.EqualValues(1, events[0].Count)
+	s.Equal(`Some stack outputs are not compatible with kubernetes secret key format: foo!,`, events[0].Message)
+	s.Equal(v1.EventTypeWarning, events[0].Type)
+	s.Equal("Secret", events[0].InvolvedObject.Kind)
+	s.Equal("stack-output-foobar", events[0].InvolvedObject.Name)
+
+}
+
+func TestStackOutputRepository(t *testing.T) {
+	suite.Run(t, new(StackOutputRepositorySuite))
+}

--- a/internal/spacelift/models/stack.go
+++ b/internal/spacelift/models/stack.go
@@ -1,5 +1,9 @@
 package models
 
+import (
+	"regexp"
+)
+
 type Stack struct {
 	Id      string
 	Url     string
@@ -9,4 +13,11 @@ type Stack struct {
 type StackOutput struct {
 	Id    string
 	Value string
+}
+
+// See https://kubernetes.io/docs/concepts/configuration/secret/#restriction-names-data
+var validOutputId = regexp.MustCompile(`^[a-zA-Z0-9\-_.]+$`)
+
+func (o *StackOutput) IsCompatibleWithKubeSecret() bool {
+	return validOutputId.MatchString(o.Id)
 }

--- a/internal/spacelift/models/stack_test.go
+++ b/internal/spacelift/models/stack_test.go
@@ -1,0 +1,74 @@
+package models
+
+import "testing"
+
+func TestStackOutput_IsCompatibleWithKubeSecret(t *testing.T) {
+	tests := []struct {
+		name   string
+		output StackOutput
+		want   bool
+	}{
+		{
+			name: "valid",
+			output: StackOutput{
+				Id: "foobar",
+			},
+			want: true,
+		},
+		{
+			name: "valid-alphanum",
+			output: StackOutput{
+				Id: "Foobar123",
+			},
+			want: true,
+		},
+		{
+			name: "valid-dash",
+			output: StackOutput{
+				Id: "foobar-",
+			},
+			want: true,
+		},
+		{
+			name: "valid underscore",
+			output: StackOutput{
+				Id: "foobar_",
+			},
+			want: true,
+		},
+		{
+			name: "valid dot",
+			output: StackOutput{
+				Id: "foobar.",
+			},
+			want: true,
+		},
+
+		// Invalid ones
+		{
+			name: "invalid empty",
+			output: StackOutput{
+				Id: "",
+			},
+		},
+		{
+			name: "invalid special char",
+			output: StackOutput{
+				Id: "foobar!",
+			},
+		},
+		{
+			name: "invalid space",
+			output: StackOutput{
+				Id: " foobar",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.output.IsCompatibleWithKubeSecret(); got != tt.want {
+				t.Errorf("IsCompatibleWithKubeSecret() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/tests/integration/event_suite.go
+++ b/tests/integration/event_suite.go
@@ -1,0 +1,27 @@
+package integration
+
+import (
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/fields"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type WithEventHelper struct {
+	*IntegrationTestSuite
+}
+
+func (s *WithEventHelper) FindEvents(object types.NamespacedName, reason string) ([]v1.Event, error) {
+	var events v1.EventList
+	if err := s.Client().List(s.Context(), &events, &client.ListOptions{
+		Namespace: object.Namespace,
+		FieldSelector: fields.SelectorFromSet(fields.Set{
+			"involvedObject.name": object.Name,
+			"reason":              reason,
+		}),
+	}); err != nil {
+		return nil, err
+	}
+
+	return events.Items, nil
+}

--- a/tests/integration/stack_suite.go
+++ b/tests/integration/stack_suite.go
@@ -81,7 +81,7 @@ func (s *WithStackSuiteHelper) GetStackOutput(stack *v1beta1.Stack) (*v1.Secret,
 	secret := &v1.Secret{}
 	if err := s.Client().Get(s.Context(), types.NamespacedName{
 		Namespace: stack.Namespace,
-		Name:      "stack-output-" + stack.Status.Id,
+		Name:      "stack-output-" + stack.Name,
 	}, secret); err != nil {
 		return nil, err
 	}

--- a/tests/integration/suite.go
+++ b/tests/integration/suite.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"time"
@@ -63,8 +64,10 @@ func (s *IntegrationTestSuite) SetupSuite() {
 	)
 	s.ctx, s.cancel = context.WithCancel(context.Background())
 
+	_, filename, _, _ := runtime.Caller(0)
+	basePath := path.Join(path.Dir(filename), "..", "..")
 	s.testEnv = &envtest.Environment{
-		CRDDirectoryPaths:     []string{filepath.Join("..", "..", "config", "crd", "bases")},
+		CRDDirectoryPaths:     []string{filepath.Join(basePath, "config", "crd", "bases")},
 		ErrorIfCRDPathMissing: true,
 
 		// The BinaryAssetsDirectory is only required if you want to run the tests directly
@@ -72,7 +75,7 @@ func (s *IntegrationTestSuite) SetupSuite() {
 		// default path defined in controller-runtime which is /usr/local/kubebuilder/.
 		// Note that you must have the required binaries setup under the bin directory to perform
 		// the tests directly. When we run make test it will be setup and used automatically.
-		BinaryAssetsDirectory: filepath.Join("..", "..", "bin", "k8s",
+		BinaryAssetsDirectory: filepath.Join(basePath, "bin", "k8s",
 			fmt.Sprintf("1.28.0-%s-%s", runtime.GOOS, runtime.GOARCH)),
 	}
 


### PR DESCRIPTION
- Secret name should match RFC1123
- Each output name should match [this format](https://kubernetes.io/docs/concepts/configuration/secret/#restriction-names-data)