### PR TITLE
fix: disable metrics server in tests

### DIFF
--- a/tests/integration/suite.go
+++ b/tests/integration/suite.go
@@ -20,6 +20,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	kubezap "sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/spacelift-io/spacelift-operator/api/v1beta1"
 	"github.com/spacelift-io/spacelift-operator/internal/k8s/repository"
@@ -94,6 +95,9 @@ func (s *IntegrationTestSuite) SetupSuite() {
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Logger: logger,
 		Scheme: scheme.Scheme,
+		Metrics: metricsserver.Options{
+			BindAddress: "0",
+		},
 	})
 	s.Require().NoError(err)
 


### PR DESCRIPTION
This was causing issues in test because trying to bind `:8080`.
Since we don't really need a metric server in test I just disabled it.