### PR TITLE
feat: add helmify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ Dockerfile.cross
 
 /dist
 /build
+/chart

--- a/Makefile
+++ b/Makefile
@@ -192,3 +192,14 @@ controller-manifests: manifests kustomize ## Generates the manifests required to
 	# order to build the manifests. Once it's done we need to reset the file, otherwise GoReleaser
 	# will complain about a dirty git state if trying to release.
 	git checkout -q config/manager/kustomization.yaml
+
+
+HELMIFY ?= $(LOCALBIN)/helmify
+
+.PHONY: helmify
+helmify: $(HELMIFY) ## Download helmify locally if necessary.
+$(HELMIFY): $(LOCALBIN)
+	test -s $(LOCALBIN)/helmify || GOBIN=$(LOCALBIN) go install github.com/arttor/helmify/cmd/helmify@latest
+
+helm: manifests kustomize helmify
+	$(KUSTOMIZE) build config/default | $(HELMIFY) -crd-dir


### PR DESCRIPTION
Add a new `make helm` target that generates the helm chart based on generated manifests.

This can be used when releasing a new version to generate helm templates and compare them to the actual chart.

Those Makefile targets are coming from here https://github.com/arttor/helmify?tab=readme-ov-file#integrate-to-your-operator-sdkkubebuilder-project