### PR TITLE
fix: handle aws integration attach/detach on stack update

### DIFF
--- a/internal/logging/keys.go
+++ b/internal/logging/keys.go
@@ -6,8 +6,9 @@ const (
 	RunId    = "run.id"
 	RunState = "run.state"
 
-	StackName = "stack.name"
-	StackId   = "stack.id"
+	StackName             = "stack.name"
+	StackId               = "stack.id"
+	StackAWSIntegrationId = "stack.aws_integration_id"
 
 	SpaceId   = "space.id"
 	SpaceName = "space.name"


### PR DESCRIPTION
We were not handling AWS integration changes on stack update.

We also need to detach/reattach an integration if read/write is changed.