### PR TITLE
fix: retry failed updates

### DIFF
--- a/internal/controller/context_controller.go
+++ b/internal/controller/context_controller.go
@@ -229,8 +229,7 @@ func (r *ContextReconciler) handleUpdateContext(ctx context.Context, context *v1
 	spaceliftUpdatedContext, err := r.SpaceliftContextRepository.Update(ctx, context)
 	if err != nil {
 		logger.Error(err, "Unable to update the context in spacelift")
-		// TODO: Implement better error handling and retry errors that could be retried
-		return ctrl.Result{}, nil
+		return ctrl.Result{}, err
 	}
 
 	context.SetContext(spaceliftUpdatedContext)

--- a/internal/controller/policy_controller.go
+++ b/internal/controller/policy_controller.go
@@ -158,7 +158,7 @@ func (r *PolicyReconciler) handleUpdatePolicy(ctx context.Context, policy *v1bet
 	spaceliftUpdatedPolicy, err := r.SpaceliftPolicyRepository.Update(ctx, policy)
 	if err != nil {
 		logger.Error(err, "Unable to update the policy in spacelift")
-		return ctrl.Result{}, nil
+		return ctrl.Result{}, err
 	}
 
 	res, err := r.updatePolicyStatus(ctx, policy, *spaceliftUpdatedPolicy)

--- a/internal/controller/run_controller.go
+++ b/internal/controller/run_controller.go
@@ -111,7 +111,6 @@ func (r *RunReconciler) handleNewRun(ctx context.Context, run *v1beta1.Run, stac
 	spaceliftRun, err := r.SpaceliftRunRepository.Create(ctx, stack)
 	if err != nil {
 		logger.Error(err, "Unable to create the run in spacelift")
-		// TODO: Implement better error handling and retry errors that could be retried
 		return ctrl.Result{}, nil
 	}
 

--- a/internal/controller/space_controller.go
+++ b/internal/controller/space_controller.go
@@ -111,7 +111,7 @@ func (r *SpaceReconciler) handleUpdateSpace(ctx context.Context, space *v1beta1.
 	spaceliftUpdatedSpace, err := r.SpaceliftSpaceRepository.Update(ctx, space)
 	if err != nil {
 		logger.Error(err, "Unable to update the space in spacelift")
-		return ctrl.Result{}, nil
+		return ctrl.Result{}, err
 	}
 
 	res, err := r.updateSpaceStatus(ctx, space, *spaceliftUpdatedSpace)

--- a/internal/controller/stack_controller.go
+++ b/internal/controller/stack_controller.go
@@ -157,8 +157,7 @@ func (r *StackReconciler) handleUpdateStack(ctx context.Context, stack *v1beta1.
 	spaceliftUpdatedStack, err := r.SpaceliftStackRepository.Update(ctx, stack)
 	if err != nil {
 		logger.Error(err, "Unable to update the stack in spacelift")
-		// TODO: Implement better error handling and retry errors that could be retried
-		return ctrl.Result{}, nil
+		return ctrl.Result{}, err
 	}
 
 	res, err := r.updateStackStatus(ctx, stack, *spaceliftUpdatedStack)


### PR DESCRIPTION
Previously we decided not to retry on failure when updating a resource.

This can cause issues if the reason of the failure is because a dependent resource needs to be updated first.
This race is expected since we do not control the order of execution of updates.

I changed our approach to return the update error, this will make the controller retry update errors by default.

The following scenario is now covered:
- Create a stack and a context in a given space `A`
- Change the space for the context and the stack to space `B`
- The stack is updated first but this fails because at that point in time the context is still in space `A`

And thus we follow the self-healing paradigm of k8s mindset.